### PR TITLE
[feat] 로그아웃 시 모든 Zustand store 상태 초기화

### DIFF
--- a/src/components/user-profile/UserProfileCard.tsx
+++ b/src/components/user-profile/UserProfileCard.tsx
@@ -7,6 +7,12 @@ import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import useUserData from '@/hooks/useUserData'
 import { createClient } from '@/libs/supabase/client'
+import { useCalendarStore } from '@/store/calendarStore'
+import { useModal } from '@/store/modalStore'
+import { usePetStore } from '@/store/petStore'
+import { useProfileCreationStore } from '@/store/profileCreationStore'
+import { useScheduleStore } from '@/store/scheduleStore'
+import { useUserStore } from '@/store/userStore'
 
 interface UserProfileCardProps {
   user: User
@@ -16,6 +22,14 @@ export default function UserProfileCard({ user }: UserProfileCardProps) {
   const router = useRouter()
 
   const { userData } = useUserData(user)
+
+  // Zustand stores
+  const { resetUser } = useUserStore()
+  const { resetPets } = usePetStore()
+  const { resetSchedules } = useScheduleStore()
+  const { resetCalendar } = useCalendarStore()
+  const { resetModal } = useModal()
+  const { resetDraftPet } = useProfileCreationStore()
 
   // user테이블에서 이름 가져오기
   // 없으면 이메일 앞부분 사용
@@ -37,6 +51,14 @@ export default function UserProfileCard({ user }: UserProfileCardProps) {
       toast.error('로그아웃 실패')
       return
     }
+
+    // 모든 Zustand store 초기화
+    resetUser()
+    resetPets()
+    resetSchedules()
+    resetCalendar()
+    resetModal()
+    resetDraftPet()
 
     toast.success('로그아웃되었습니다')
     router.push('/')

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -11,6 +11,7 @@ interface CalendarStore {
   setCurrentMonth: (month: number) => void
   setYearMonth: (year: number, month: number) => void
   setSelectedDate: (date: Date | null) => void
+  resetCalendar: () => void
 }
 
 /**
@@ -31,4 +32,17 @@ export const useCalendarStore = create<CalendarStore>(set => ({
   setYearMonth: (year: number, month: number) =>
     set({ currentYear: year, currentMonth: month }),
   setSelectedDate: (date: Date | null) => set({ selectedDate: date }),
+
+  /**
+   * Calendar Store 초기화
+   * - 로그아웃 시 현재 날짜로 리셋
+   */
+  resetCalendar: () => {
+    const now = new Date()
+    set({
+      currentYear: now.getFullYear(),
+      currentMonth: now.getMonth() + 1,
+      selectedDate: now,
+    })
+  },
 }))

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -20,10 +20,16 @@ interface ModalState {
   active: ModalEntry | null
   openModal: (entry: ModalEntry) => void
   closeModal: () => void
+  resetModal: () => void
 }
 
 export const useModal = create<ModalState>(set => ({
   active: null,
   openModal: entry => set({ active: entry }),
   closeModal: () => set({ active: null }),
+  /**
+   * Modal Store 초기화
+   * - 로그아웃 시 사용
+   */
+  resetModal: () => set({ active: null }),
 }))

--- a/src/store/petStore.ts
+++ b/src/store/petStore.ts
@@ -31,6 +31,7 @@ interface PetStore {
   fetchPetSummary: (user: User) => Promise<void>
   selectedPet?: Pet | undefined
   fetchSelectedPet: (id: string | null) => Promise<void>
+  resetPets: () => void
 }
 
 /**
@@ -108,5 +109,17 @@ export const usePetStore = create<PetStore>((set, get) => ({
     if (!id) return
     const data = await getSelectedPet(id)
     set({ selectedPet: data })
+  },
+
+  /**
+   * Pet Store 초기화
+   * - 로그아웃 시 사용
+   */
+  resetPets: () => {
+    set({
+      petList: [],
+      selectedPetId: null,
+      selectedPet: undefined,
+    })
   },
 }))

--- a/src/store/scheduleStore.ts
+++ b/src/store/scheduleStore.ts
@@ -40,6 +40,7 @@ interface ScheduleStore {
   addAntiparasitic: (data: CreateAntiparasiticData) => Promise<void>
   addMedical: (data: CreateMedicalData) => Promise<void>
   addWalk: (data: CreateWalkData) => Promise<void>
+  resetSchedules: () => void
 }
 
 // 모든 카테고리(기본값)
@@ -368,5 +369,19 @@ export const useScheduleStore = create<ScheduleStore>((set, get) => ({
 
       throw err
     }
+  },
+
+  /**
+   * Schedule Store 초기화
+   * - 로그아웃 시 사용
+   */
+  resetSchedules: () => {
+    set({
+      schedules: [],
+      isLoading: false,
+      error: null,
+      currentPetId: null,
+      activeFilters: ALL_CATEGORIES,
+    })
   },
 }))

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -5,6 +5,7 @@ import { createClient } from '../libs/supabase/client'
 interface UserState {
   user: User | null
   setUser: () => Promise<void>
+  resetUser: () => void
 }
 
 const supabase = createClient()
@@ -14,6 +15,7 @@ const supabase = createClient()
  *
  * {User | null} user - 현재 로그인한 사용자 정보, 로그인 안됐으면 null
  * {() => Promise<void>} setUser - Supabase에서 사용자 정보를 가져와 상태를 업데이트하는 함수
+ * {() => void} resetUser - 사용자 상태를 초기화하는 함수 (로그아웃 시 사용)
  */
 export const useUserStore = create<UserState>(set => ({
   user: null,
@@ -23,4 +25,5 @@ export const useUserStore = create<UserState>(set => ({
     } = await supabase.auth.getUser()
     set({ user })
   },
+  resetUser: () => set({ user: null }),
 }))


### PR DESCRIPTION
- 각 store에 reset 함수 추가
  - userStore: resetUser()
  - petStore: resetPets()
  - scheduleStore: resetSchedules()
  - calendarStore: resetCalendar()
  - modalStore: resetModal()

- UserProfileCard의 handleLogout에서 모든 store 초기화 호출

- 로그아웃 시 이전 사용자의 데이터가 Sidebar 및 다른 컴포넌트에 남지 않도록 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #
